### PR TITLE
[FIX][#11]: AVI 로직 개선

### DIFF
--- a/python_engine/core/analyzer/basic_info_parser.py
+++ b/python_engine/core/analyzer/basic_info_parser.py
@@ -4,7 +4,8 @@ import subprocess
 import json
 from fractions import Fraction
 
-FFPROBE_PATH = r"E:\Retato\bin\ffprobe.exe"
+# FFprobe 실행 파일 경로 (프로젝트 bin 폴더 기준)
+FFPROBE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../bin/ffprobe.exe'))
 
 def file_format(file_path):
     with open(file_path, 'rb') as f:

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -1,5 +1,4 @@
 import os
-import struct
 import pyewf
 import pytsk3
 import tkinter as tk
@@ -9,7 +8,7 @@ import time
 import logging
 import tempfile
 import shutil
-import json, sys
+import json
 from python_engine.core.recovery.mp4.extract_slack import recover_mp4_slack
 from python_engine.core.recovery.avi.extract_slack import recover_avi_slack
 from python_engine.core.analyzer.basic_info_parser import get_basic_info
@@ -165,61 +164,46 @@ def extract_video_files(fs_info, output_dir, path="/", total_count=None, progres
             continue
 
         # AVI 처리
-        temp_dir = os.path.join(output_dir, category, 'tmp')
-        os.makedirs(temp_dir, exist_ok=True)
-        temp_avi = os.path.join(temp_dir, name)
+        video_stem = os.path.splitext(name)[0]
+        base_dir = os.path.join(output_dir, category, video_stem)
+        os.makedirs(base_dir, exist_ok=True)
+
+        temp_avi = os.path.join(base_dir, f"{name}")
         with open(temp_avi, 'wb') as wf:
             wf.write(data)
 
-        # 슬랙 & 채널 복원
-        base_dir = os.path.join(output_dir, category)
-        raw_dir = os.path.join(base_dir, 'raw')
-        slack_dir = os.path.join(base_dir, 'slack')
-        channels_dir = os.path.join(base_dir, 'channels')
-        os.makedirs(raw_dir, exist_ok=True)
-        os.makedirs(slack_dir, exist_ok=True)
-        os.makedirs(channels_dir, exist_ok=True)
-
         avi_info = recover_avi_slack(
             input_avi=temp_avi,
-            raw_out_dir=raw_dir,
-            slack_out_dir=slack_dir,
-            channels_out_dir=channels_dir,
+            base_dir=base_dir,
             target_format='mp4'
         )
 
-        # 전체 채널 MP4 복사
-        for label, info in avi_info.items():
-            full_mp4 = info.get('full_path')
-            if full_mp4 and os.path.exists(full_mp4):
-                chan_dir = os.path.join(output_dir, category, label)
-                os.makedirs(chan_dir, exist_ok=True)
-                dst = os.path.join(chan_dir, os.path.basename(full_mp4))
-                shutil.copy2(full_mp4, dst)
+        if avi_info is None:
+            # 손상된 파일이거나 AVI 헤더가 올바르지 않은 경우 건너뜁니다.
+            continue
+        origin_video = avi_info.get('origin_video', temp_avi)
 
-        # 결과 저장 - AVI의 경우 slack_info 추가
-        # 각 채널의 slack_rate 중 최대값을 사용하거나 평균값을 사용
         slack_rates = [info.get('slack_rate', 0) for info in avi_info.values() if 'slack_rate' in info]
         overall_slack_rate = max(slack_rates) if slack_rates else 0.0
-        
+
         slack_info = {
             'slack_rate': overall_slack_rate,
-            'channels': avi_info  # 채널별 상세 정보도 포함
+            'channels': avi_info
         }
-        
+
         analysis = {
-            'basic': get_basic_info(orig_path),
-            'integrity': get_integrity_info(orig_path),
-            'structure': get_structure_info(orig_path),
-            'slack_info': slack_info  # 분석에도 포함
+            'basic': get_basic_info(origin_video),
+            'integrity': get_integrity_info(origin_video),
+            'structure': get_structure_info(origin_video),
+            'slack_info': slack_info
         }
-        
+
         results.append({
             'name': name,
             'path': filepath,
             'size': size,
-            'origin_video': orig_path,
-            'slack_info': slack_info,  # 최상위 레벨에 slack_info 추가
+            'origin_video': origin_video,
+            'slack_info': slack_info,
             'channels': avi_info,
             'analysis': analysis
         })

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -128,9 +128,9 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
         shutil.copy2(input_avi, origin_path)
 
     results = {}
+
     common_args = [
         '-fflags', '+genpts',
-        '-vf', 'fps=30',
         '-c:v', 'libx264',
         '-preset', 'ultrafast',
         '-crf', '30'

--- a/python_engine/core/recovery/utils/ffmpeg_wrapper.py
+++ b/python_engine/core/recovery/utils/ffmpeg_wrapper.py
@@ -9,6 +9,7 @@ def convert_video(input_path, output_path, extra_args=None):
         FFMPEG_PATH,
         '-hide_banner',
         '-loglevel', 'error',
+        '-framerate', '30',
         '-i', input_path
     ]
     if extra_args:

--- a/python_engine/core/recovery/utils/ffmpeg_wrapper.py
+++ b/python_engine/core/recovery/utils/ffmpeg_wrapper.py
@@ -1,7 +1,8 @@
 import subprocess
+import os
 
-# FFmpeg 실행 파일 경로
-FFMPEG_PATH = r"E:\Retato\bin\ffmpeg.exe"
+# FFmpeg 실행 파일 경로 (프로젝트 bin 폴더 기준)
+FFMPEG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../bin/ffmpeg.exe'))
 
 def convert_video(input_path, output_path, extra_args=None):
     cmd = [

--- a/python_engine/main.py
+++ b/python_engine/main.py
@@ -1,15 +1,11 @@
 import os
 import sys
-
-# ✅ 1. 루트 경로 삽입: D:/Retato/app
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-# ✅ 2. 이제서야 import
 import json
 import shutil
 from python_engine.core.image_loader.e01_parser import extract_videos_from_e01
 from python_engine.core.output.download_frame import download_frames
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 def main(e01_path, choice=None, download_dir=None):
     # ─── 0) 다운로드 모드 & 기존 temp 폴더 재사용 분기 ───
@@ -40,7 +36,6 @@ def main(e01_path, choice=None, download_dir=None):
             print(json.dumps({"analysisPath": tmp_json}), flush=True)
             return
 
-    # ────────────────────────────────────────────
     # ─── 2) 다운로드 모드: choice와 download_dir이 모두 주어졌을 때 실행 ───
     DOWNLOAD_DIR = download_dir
     os.makedirs(DOWNLOAD_DIR, exist_ok=True)


### PR DESCRIPTION
## 작업 내용
- AVI 채널 분리 및 slack 복원 로직 전반 개선
- 슬랙 영상 저장명 및 디렉터리 구조 정리 (채널별/세선별 관리)
- 일부 불필요한 코드(import) 제거 및 실행 경로 관련 이슈 수정
- ffmpeg 실행 파일 경로를 상대경로로 변경하여 환경 의존성 완화

### 스크린샷

**1. 추출된 파일 목록**
<img width="646" height="606" alt="image" src="https://github.com/user-attachments/assets/de7bbf9b-6321-49b8-a42a-7b1f4d0a8890" /> 

- 원본 영상명을 기준으로 디렉터리가 생성됩니다.
 
</br>

**2. 채널 디렉터리 구조**
<img width="643" height="140" alt="image" src="https://github.com/user-attachments/assets/b5eed87f-d606-47cc-843a-51f0b2fa10c7" />

- 각 영상 디렉터리 안에는 `front/rear/side` 채널별 폴더가 자동 생성됩니다.
- 채널이 없는 경우에는 해당 폴더가 자동으로 삭제됩니다.
  - 예: 현재 side 없음 → front/rear만 존재
- 또한, 원본 영상은 `.avi` 형태로 함께 저장됩니다.
 
</br>

**3. 채널별 산출물 예시(front)**
<img width="488" height="178" alt="image" src="https://github.com/user-attachments/assets/37c9ec6f-43e6-4af5-a95e-42250569f8b2" />

- `영상명_front.mp4` : 채널 분리된 원본 영상
- `영상명_front_slack.mp4` : 슬랙 데이터가 존재할 경우 생성되는 슬랙 복원 영상 

## 리뷰 요구사항
- 원본 영상 길이가 1분인데, 채널 분리된 영상은 1분 12초처럼 재생 시간이 늘어나는 문제가 있습니다..! 이 부분 어떻게 해결하는게 좋을지 의견 부탁드려요.
- 채널 분리 및 슬랙 영상 생성 과정에서 재인코딩이 포함되어 추출 시간이 꽤 오래 걸려요. 멘토님 영상 기준 약 730개 영상 중 80개 정도 추출하는데 1시간정도 걸렸습니다... (나머지는 중간에 포기했어요..ㅎ) 인코딩 옵션 최적화나 다른 방식이 있을지 검토 부탁드려요.
- 원본은 AVI 포맷이고, 분리된 채널/슬랙 영상은 모두 MP4로 변환하도록 되어 있는데 이 방식이 적절한지, 아니면 원본 포맷을 유지하는 게 나을지 피드백 부탁드려요.