### PR TITLE
[Refactor][#13] AVI/MP4 분석 및 복원 결과 JSON 구조 정리

### DIFF
--- a/python_engine/core/analyzer/basic_info_parser.py
+++ b/python_engine/core/analyzer/basic_info_parser.py
@@ -5,7 +5,7 @@ import json
 from fractions import Fraction
 
 # FFprobe 실행 파일 경로 (프로젝트 bin 폴더 기준)
-FFPROBE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../bin/ffprobe.exe'))
+FFPROBE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../bin/ffprobe.exe'))
 
 def file_format(file_path):
     with open(file_path, 'rb') as f:
@@ -79,14 +79,9 @@ def video_metadata(file_path):
             'frame_rate': 0.0
         }
 
-def file_size(file_path):
-    # 파일 크기 (bytes 단위) 반환
-    return os.path.getsize(file_path)
-
 def get_basic_info(file_path):
     return {
         "format": file_format(file_path),
-        "file_size": file_size(file_path),
         "timestamps": file_creation_time(file_path),
         "video_metadata": video_metadata(file_path)
     }

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -157,7 +157,8 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                         'recovered': True,
                         'video_path': slack_mp4,
                         'frame_count': slack_count,
-                        'slack_rate': float(recovered_bytes / len(data) * 100)
+                        'slack_rate': float(recovered_bytes / len(data) * 100),
+                        'slack_size_bytes': recovered_bytes
                     }
 
         # 2) 원본 채널 분리
@@ -188,5 +189,4 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                 logger.warning(f"[{label}] 폴더 삭제 실패: {e}")
 
     results['source_path'] = origin_path
-    results['file_size_bytes'] = len(data)
     return results

--- a/python_engine/main.py
+++ b/python_engine/main.py
@@ -54,7 +54,7 @@ def main(e01_path, choice=None, download_dir=None):
                     dst = os.path.join(DOWNLOAD_DIR, "recovery", rel)
                     os.makedirs(os.path.dirname(dst), exist_ok=True)
                     shutil.copy2(src, dst)
-        # 슬랙 히든 MP4
+        # Slack MP4
         for category in os.listdir(output_dir):
             slack_dir = os.path.join(output_dir, category, "slack")
             if os.path.isdir(slack_dir):
@@ -62,7 +62,7 @@ def main(e01_path, choice=None, download_dir=None):
                     for fn in files:
                         if fn.lower().endswith(".mp4"):
                             src = os.path.join(root, fn)
-                            dst = os.path.join(DOWNLOAD_DIR, "recovery_hidden", fn)
+                            dst = os.path.join(DOWNLOAD_DIR, "recovery_slack", fn)
                             os.makedirs(os.path.dirname(dst), exist_ok=True)
                             shutil.copy2(src, dst)
         print("▶ 영상 저장 완료.", file=sys.stderr)
@@ -81,7 +81,7 @@ def main(e01_path, choice=None, download_dir=None):
             if output_path and os.path.exists(output_path):
                 items.append({
                     "output_path": output_path,
-                    "filename": f"{os.path.splitext(info['name'])[0]}_hidden.mp4"
+                    "filename": f"{os.path.splitext(info['name'])[0]}_slack.mp4"
                 })
         print(f"[DEBUG] items: {items}")
         download_frames(items, download_dir=DOWNLOAD_DIR)


### PR DESCRIPTION
## 작업 내용
> 영상 분석 및 복원 결과(JSON) 구조 개선 및 슬랙 관련 필드 정리 작업 진행했습니다.

- MP4와 AVI 모두 다음 기준에 따라 JSON 필드를 정리했습니다
  - 중복된 `size` 관련 필드 제거
  - 슬랙 영상의 바이트(`slack_size_bytes`) 및 비율(`slack_rate`) 필드 명시
  - 불필요하거나 사용되지 않는 필드 제거
  - 분석 결과 구조(`analysis`) 내 필드 정리 및 포맷 개선

---

## 필드 설명
### 실제 MP4 예시
```
{
  "name": "REC_2025_07_06_17_10_21_F.MP4",
  "path": "/Driving/REC_2025_07_06_17_10_21_F.MP4",
  "size": 88080384,
  "origin_video": "C:\\Users\\akdbw\\AppData\\Local\\Temp\\retato_impo0k3i\\Driving\\REC_2025_07_06_17_10_21_F.MP4",
  "slack_info": {
    "recovered": true,
    "file_size_bytes": 3807813,
    "frame_count": 93,
    "video_path": "C:\\Users\\akdbw\\AppData\\Local\\Temp\\retato_impo0k3i\\Driving\\slack\\REC_2025_07_06_17_10_21_F_slack.mp4",
    "slack_rate": 4.39857528323219
  },
  "analysis": {
    "basic": {
      "format": "MP4",
      "timestamps": {
        "created": "2025-08-30 01:29:50",
        "modified": "2025-08-30 01:29:51",
        "accessed": "2025-08-30 01:29:51"
      },
      "video_metadata": {
        "duration": 57.057,
        "codec": "h264",
        "width": 1920,
        "height": 1080,
        "frame_rate": 29.97002997002997
      }
    },
    "integrity": {
      "damaged": false,
      "reasons": []
    },
    "structure": {
      "type": "mp4",
      "structure": [
        "ftyp box start offset: 0x0",
        "ftyp box size: 0x20",
        "mdat box start offset: 0x20",
        "mdat box size: 0x49268a1",
        "moov box start offset: 0x49268c1",
        "moov box size: 0x7909",
        "    mvhd box start offset: 0x49268c9",
        "    mvhd box size: 0x6c",
        "    udta box start offset: 0x4926935",
        "    udta box size: 0x95",
        "    trak box start offset: 0x49269ca",
        "    trak box size: 0x388f",
        "        tkhd box start offset: 0x49269d2",
        ...
        "free box start offset: 0x492e1ca",
        "free box size: 0xad1e36"
      ]
    }
  }
}
```
> 실제 MP4 분석 및 복원 결과를 대상으로 설명드립니다.

### 1. 기본 정보

| 필드 | 설명 |
|------|------|
| `name` | 영상 파일명 |
| `path` | E01 내부에서의 파일 경로 |
| `size` | 원본 영상 크기 (bytes 단위) |
| `origin_video` | 복원된 원본 영상의 실제 저장 경로 |

---

### 2. `slack_info`

| 필드 | 설명 |
|-------|--------|
| `recovered` | 슬랙 복원 성공 여부 |
| `slack_size_bytes` | 복원된 슬랙 영상의 바이트 수 |
| `frame_count` | 복원된 슬랙 프레임 수 <br>**(❗ 프론트에서 사용하지 않는데 제거할지 검토 요청)** |
| `video_path` | 복원된 슬랙 영상(mp4)의 저장 경로 |
| `slack_rate` | 원본 대비 슬랙 데이터의 비율 (%)<br> **(❗ 프론트가 아닌 백엔드에서 직접 제공하도록 변경해야함)<br> (❗소수점 둘째 자리까지 제한 필요 여부 검토 요청)** |

---

### 3. `analysis`

#### 3.1 `basic`

| 필드 | 설명 |
|--------|--------|
| `format` | 영상 컨테이너 포맷 (MP4, AVI 등) |
| `timestamps` | 생성/수정/접근 시간<br>**(❗ 슬랙 영상을 생성하는 것이므로 모두 다 같은 값이기에 1개로 축소할지 검토 요청)** |

#### 3.2 `video_metadata`

| 필드 | 설명 |
|--------|--------|
| `duration` | 영상 재생 시간 (초) |
| `codec` | 코덱 정보 (예: h264) |
| `width`, `height` | 해상도 |
| `frame_rate` | 프레임률 (fps) <br>**(❗ 소수점 2자리 제한할지 검토 요청)** |

#### 3.3 `integrity`

| 필드 | 설명 |
|--------|--------|
| `damaged` | 영상 손상 여부 |
| `reasons` | 손상 사유 (복수 가능) |

#### 3.4 `structure`

| 필드 | 설명 |
|--------|--------|
| `type` | 컨테이너 타입 (mp4/avi) |
| `structure` | 컨테이너 내부 구조 정보 |

---

## 리뷰 요구사항
- `frame_count`는 프론트에서 사용하지 않는데 JSON 내에 기록해두어야 할까요?
- `slack_rate`는 현재  `4.39857528323219`와 같이 출력되고 있습니다. 백엔드에서 소수점 둘째 자리까지 제한하는 것이 좋을까요? 프론트에서 처리하는 것보다 백에서 처리하는 게 좋을 것 같다고 생각되는데 어떻게 생각하시나요?
- `slack_size_bytes`, `size` 등 바이트 수 표현은 그대로 전달 중인데, 
   쉼표(`1,234,567`) 포맷 또는 단위(`1.2 MB`) 표기를 **백엔드에서 처리할지** 의견 부탁드립니다.
   프론트에서는 백에서 계산된 결과를 바로 가져오는 것이 더 좋을 것 같거든요!
   적용한다면 쉼표 혹은 단위 중 어느 것이 나을지 알려주세요~

## 참고사항
- 기존 UI에서 제거했던 슬랙 영상의 크기(`slack_size_bytes`)를 다시 추가해도 좋을 것 같습니다!
  현재 영상별 슬랙 정보에는 슬랙 비율과 프로그래스바가 전부이기에 원본 영상 바이트랑 슬랙 영상 바이트
  둘 다 다시 추가하는 방향을 고려해도 좋을 것 같습니다.
- 원본 영상의 크기(`size`)는 `e01_parser.py`에서만 유지하고, `basic_info_parser.py` 등 중복 필드는 제거했습니다.
- AVI는 `channels` 키 아래에 `front`, `rear`, `side` 채널별로 결과가 분리되며, 각 채널의 슬랙 복원 결과는 아래와 같은 구조로 표현됩니다.
```
  {
  "name": "BlackSys_X2000.avi",
  "path": "/Normal/BlackSys_X2000.avi",
  "size": 50274304,
  "origin_video": ".../BlackSys_X2000.avi",
  "channels": {
    "front": {
      "recovered": true,
      "video_path": ".../front_slack.mp4",
      "frame_count": 144,
      "slack_rate": 3.23,
      "slack_size_bytes": 1624200,
      "full_video_path": ".../front.mp4"
    },
    "rear": {
      "recovered": false,
      "video_path": null,
      "frame_count": 0,
      "slack_rate": 0.0,
      "slack_size_bytes": 0,
      "full_video_path": ".../rear.mp4"
    }
  },
  "analysis": {
    "basic": {
      "format": "AVI",
      "timestamps": {
        "created": "2025-08-30 01:45:12",
        "modified": "2025-08-30 01:45:13",
        "accessed": "2025-08-30 01:45:13"
      },
      "video_metadata": {
        "duration": 58.8,
        "codec": "h264",
        "width": 1280,
        "height": 720,
        "frame_rate": 29.97
      }
    },
    "integrity": {
      "damaged": false,
      "reasons": []
    },
    "structure": {
      "type": "avi",
      "structure": [
        "RIFF header offset: 0x0",
        "LIST stream offset: 0x1000",
        "00dc chunk offset: 0x2000",
        "idx1 chunk offset: 0x480000"
      ]
    }
  }
}
```
  > 해당 결과는 AVI 분석 및 복원 결과 JSON 예시입니다.
  > AVI의 JSON을 제대로 획득하지 못했기에 최대한 MP4와 비슷한 구조를 유지하려고 했습니다.
  > 다만 실제 결과는 채널 복원 유무에 따라 달라질 수 있으며, 채널 구조 관련 오류가 발생하면 추후 개선 예정입니다. 

‼️모든 작업은 **백엔드에서만 진행**하였다는 것을 다시한번 알려드립니다.