### PR TITLE
[Refactor][#18] 결과 JSON 정리 (slack_rate/byte단위/불필요 필드/오디오 메타데이터 정비)

### DIFF
--- a/python_engine/core/analyzer/basic_info_parser.py
+++ b/python_engine/core/analyzer/basic_info_parser.py
@@ -63,7 +63,7 @@ def video_metadata(file_path):
         duration = float(stream.get('duration', 0.0))
         fps_str = stream.get('r_frame_rate', '0/1')
 
-        frame_rate = float(Fraction(fps_str)) if fps_str != '0/0' else 0.0
+        frame_rate = round(float(Fraction(fps_str)), 2) if fps_str != '0/0' else 0.0
 
         return {
             'duration': duration,

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -188,7 +188,7 @@ def extract_videos_from_e01(e01_path):
         print(json.dumps({"event": "disk_full", "free": free, "needed": needed}), flush=True)
         return [], None, 0
 
-    output_dir = tempfile.mkdtemp(prefix="retato_", dir=temp_base)
+    output_dir = tempfile.mkdtemp(prefix="Virex_", dir=temp_base)
 
     for partition in volume:
         if partition.flags == pytsk3.TSK_VS_PART_FLAG_UNALLOC or partition.start == 0:

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -12,6 +12,7 @@ from python_engine.core.recovery.avi.extract_slack import recover_avi_slack
 from python_engine.core.analyzer.basic_info_parser import get_basic_info
 from python_engine.core.analyzer.integrity import get_integrity_info
 from python_engine.core.analyzer.struc import get_structure_info
+from python_engine.core.recovery.utils.unit import bytes_to_unit
 
 logger = logging.getLogger(__name__)
 VIDEO_EXTENSIONS = ('.mp4', '.avi')
@@ -100,7 +101,7 @@ def handle_mp4_file(name, filepath, data, output_dir, category):
     return {
         'name': name,
         'path': filepath,
-        'size': len(data),
+        'size': bytes_to_unit(len(data)),
         'origin_video': origin_video_path,
         'slack_info': slack_info,
         'analysis': build_analysis(origin_video_path)
@@ -128,7 +129,7 @@ def handle_avi_file(name, filepath, data, output_dir, category):
     return {
         'name': name,
         'path': filepath,
-        'size': len(data),
+        'size': bytes_to_unit(len(data)),
         'origin_video': origin_video_path,
         'channels': channels_only,
         'analysis': build_analysis(origin_video_path)

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -94,6 +94,19 @@ def extract_frames_from_raw(raw, sps_pps, out_fn):
 
     return count, recovered_bytes
 
+def bytes_to_unit(n):
+    if n < 1024:
+        return f"{n} B"
+    elif n < 1024**2:
+        val = n / 1024
+        return f"{val:.1f} KB".rstrip("0").rstrip(".")
+    elif n < 1024**3:
+        val = n / 1024**2
+        return f"{val:.1f} MB".rstrip("0").rstrip(".")
+    else:
+        val = n / 1024**3
+        return f"{val:.1f} GB".rstrip("0").rstrip(".")
+
 def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
     os.makedirs(base_dir, exist_ok=True)
     with open(input_avi, "rb") as f:
@@ -134,7 +147,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
             sps_pps = extract_sps_pps_from_raw(channel_data, codec, label)
             if sps_pps:
                 slack_h264 = os.path.join(ch_dir, f"{basename}_{label}_slack.h264")
-                slack_count, recovered_bytes = extract_frames_from_raw(channel_data, sps_pps, codec, slack_h264)
+                slack_count, recovered_bytes = extract_frames_from_raw(channel_data, sps_pps, slack_h264)
                 if slack_count > 0:
                     slack_mp4 = os.path.join(ch_dir, f"{basename}_{label}_slack.{target_format}")
                     convert_video(slack_h264, slack_mp4, extra_args=common_args)
@@ -142,7 +155,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                         'recovered': True,
                         'video_path': slack_mp4,
                         'slack_rate': round(recovered_bytes / len(data) * 100, 2),
-                        'slack_size_bytes': recovered_bytes
+                        'slack_size': bytes_to_unit(recovered_bytes)
                     }
 
         full_raw = extract_full_channel_bytes(data, label)
@@ -160,7 +173,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                     'recovered': False,
                     'video_path': None,
                     'slack_rate': 0.0,
-                    'slack_size_bytes': 0
+                    'slack_size': "0 B"
                 }
             results[label]['full_video_path'] = full_mp4
             has_output = True

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -141,7 +141,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                     results[label] = {
                         'recovered': True,
                         'video_path': slack_mp4,
-                        'slack_rate': float(recovered_bytes / len(data) * 100),
+                        'slack_rate': round(recovered_bytes / len(data) * 100, 2),
                         'slack_size_bytes': recovered_bytes
                     }
 
@@ -159,7 +159,8 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                 results[label] = {
                     'recovered': False,
                     'video_path': None,
-                    'slack_rate': 0.0
+                    'slack_rate': 0.0,
+                    'slack_size_bytes': 0
                 }
             results[label]['full_video_path'] = full_mp4
             has_output = True

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -141,7 +141,6 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                     results[label] = {
                         'recovered': True,
                         'video_path': slack_mp4,
-                        'frame_count': slack_count,
                         'slack_rate': float(recovered_bytes / len(data) * 100),
                         'slack_size_bytes': recovered_bytes
                     }
@@ -160,7 +159,6 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                 results[label] = {
                     'recovered': False,
                     'video_path': None,
-                    'frame_count': 0,
                     'slack_rate': 0.0
                 }
             results[label]['full_video_path'] = full_mp4

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -6,6 +6,7 @@ from python_engine.core.recovery.avi.avi_split_channel import (
     extract_full_channel_bytes,
     CHUNK_SIG)
 from python_engine.core.recovery.utils.ffmpeg_wrapper import convert_video
+from python_engine.core.recovery.utils.unit import bytes_to_unit
 
 logger = logging.getLogger(__name__)
 
@@ -93,19 +94,6 @@ def extract_frames_from_raw(raw, sps_pps, out_fn):
             pos = nal_start
 
     return count, recovered_bytes
-
-def bytes_to_unit(n):
-    if n < 1024:
-        return f"{n} B"
-    elif n < 1024**2:
-        val = n / 1024
-        return f"{val:.1f} KB".rstrip("0").rstrip(".")
-    elif n < 1024**3:
-        val = n / 1024**2
-        return f"{val:.1f} MB".rstrip("0").rstrip(".")
-    else:
-        val = n / 1024**3
-        return f"{val:.1f} GB".rstrip("0").rstrip(".")
 
 def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
     os.makedirs(base_dir, exist_ok=True)

--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -145,7 +145,6 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
         return {
             "recovered": True,
             "file_size_bytes": int(final_size),
-            "frame_count": frame_count,
             "video_path": mp4_path,
             "slack_rate": slack_rate
             }
@@ -159,7 +158,6 @@ def _fail_result():
     return {
         "recovered": False,
         "file_size_bytes": 0,
-        "frame_count": 0,
         "video_path": None,
         "slack_rate": 0.0,
     }

--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -126,7 +126,7 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
             return _fail_result()
 
         frame_count, recovered_bytes = extract_frames(slack, slack_offset, sps_pps, h264_path)
-        slack_rate = (recovered_bytes / len(data) * 100) if len(data) else 0.0
+        slack_rate = round((recovered_bytes / len(data) * 100), 2) if len(data) else 0.0
 
         if frame_count == 0:
             if os.path.exists(h264_path):

--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -3,6 +3,7 @@ import re
 import struct
 import logging
 from python_engine.core.recovery.utils.ffmpeg_wrapper import convert_video
+from python_engine.core.recovery.utils.unit import bytes_to_unit
 
 logger = logging.getLogger(__name__)
 
@@ -102,19 +103,6 @@ def extract_frames(slack, offset, sps_pps, output_path):
                 continue
 
     return recovered, recovered_bytes
-
-def bytes_to_unit(n):
-    if n < 1024:
-        return f"{n} B"
-    elif n < 1024**2:
-        val = n / 1024
-        return f"{val:.1f} KB".rstrip("0").rstrip(".")
-    elif n < 1024**3:
-        val = n / 1024**2
-        return f"{val:.1f} MB".rstrip("0").rstrip(".")
-    else:
-        val = n / 1024**3
-        return f"{val:.1f} GB".rstrip("0").rstrip(".")
 
 def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format="mp4"):
     os.makedirs(output_h264_dir, exist_ok=True)

--- a/python_engine/core/recovery/utils/unit.py
+++ b/python_engine/core/recovery/utils/unit.py
@@ -1,0 +1,12 @@
+def bytes_to_unit(n):
+    if n < 1024:
+        return f"{n} B"
+    elif n < 1024**2:
+        val = n / 1024
+        return f"{val:.1f} KB".rstrip("0").rstrip(".")
+    elif n < 1024**3:
+        val = n / 1024**2
+        return f"{val:.1f} MB".rstrip("0").rstrip(".")
+    else:
+        val = n / 1024**3
+        return f"{val:.1f} GB".rstrip("0").rstrip(".")

--- a/python_engine/core/recovery/utils/unit.py
+++ b/python_engine/core/recovery/utils/unit.py
@@ -1,12 +1,14 @@
+def _fmt1(x):
+    s = f"{x:.1f}"
+    s = s.rstrip("0").rstrip(".")
+    return s
+
 def bytes_to_unit(n):
     if n < 1024:
         return f"{n} B"
     elif n < 1024**2:
-        val = n / 1024
-        return f"{val:.1f} KB".rstrip("0").rstrip(".")
+        return f"{_fmt1(n/1024)} KB"
     elif n < 1024**3:
-        val = n / 1024**2
-        return f"{val:.1f} MB".rstrip("0").rstrip(".")
+        return f"{_fmt1(n/1024**2)} MB"
     else:
-        val = n / 1024**3
-        return f"{val:.1f} GB".rstrip("0").rstrip(".")
+        return f"{_fmt1(n/1024**3)} GB"


### PR DESCRIPTION
## 작업 내용
- 리뷰 사항을 토대로 결과 JSON의 전반적인 필드 구성 및 값 포맷을 정리했습니다.
- 소수점/단위/불필요 항목 등을 명확히 처리하여 프론트에서 더 직관적으로 사용할 수 있도록 개선했습니다.

### 주요 정리 사항
- Temp 폴더 내 폴더명 `Virex_xxx`로 변경
- `frame_count` 필드 제거
- `slack_rate` 값: 소수점 둘째 자리까지 반올림하여 전달
- `frame_rate` 값: 소수점 둘째 자리까지 반올림하여 전달
- 바이트 기반 필드들(`size`, `slack_size`)에 대해 B/KB/MB/GB 단위 표기 적용
- 원본 영상 파일의 `timestamps` 정보 (`created`, `modified`, `accessed`) 명시적으로 포함
- 오디오 메타데이터 항목 추가
  - `audio_codec`
  - `audio_rate`
  - `channels`

### 스크린샷
<img width="1020" height="570" alt="스크린샷 2025-09-01 220629" src="https://github.com/user-attachments/assets/1fcdbe3e-f3d7-4dbc-9150-08c755af3056" />

> 실제 복원한 결과 JSON의 형태입니다.

## 리뷰 요구사항 (선택)
- 바이트 단위를 표기할 때 `84.0 MB`처럼 소수점 첫째 자리에 `0`이 올 경우, `84 MB`로 표시되도록 처리했습니다.
  - 이 방식이 가독성 측면에서 더 적절한지, 혹은 소수점 `.0`까지 유지하는 편이 나은지 의견 부탁드려요!

## 참고사항
- 해당 작업은 **백엔드에서만 진행**하였습니다.
- 또한, 복원 시 생성되는 폴더명 수정도 해당 이슈 내에서 함께 정비하였습니다.