### PR TITLE
[FIX][#26]: Recovery.jsx 중복 트리거로 인한 main.py 중복 실행 수정

### DIFF
--- a/src/pages/Recovery.jsx
+++ b/src/pages/Recovery.jsx
@@ -577,17 +577,6 @@ const Recovery = ({ isDarkMode }) => {
       return () => { try { off && off(); } catch {} };
     }, []);
 
-    useEffect(() => {
-      if (isRecovering && selectedFile) {
-        window.api.startRecovery(selectedFile.path).catch((err) => {
-          if (String(err?.message || err).includes("disk_full")) {
-            setShowDiskFullAlert(true);
-            rollbackToFirst();   
-          }
-        });
-      }
-    }, [isRecovering, selectedFile]);
-
   return (
     <div className={`recovery-page ${isDarkMode ? 'dark-mode' : ''}`}>
       <Stepbar currentStep={currentStep} isDarkMode={isDarkMode} />


### PR DESCRIPTION
## 작업 내용
> 복원 시작 시 `main.py`가 두 번 실행되는 문제를 수정했습니다.

- `Recovery.jsx` 내 중복된 `useEffect` 제거
- (15)번 자동 시작 트리거만 유지, (21)번은 `disk_full` 이벤트 처리만 남김
- 수정 후 복원 시작 시 백엔드 프로세스가 한 번만 실행되는지 확인 완료

## 스크린샷
<img width="590" height="59" alt="image" src="https://github.com/user-attachments/assets/4d243731-f287-4280-8933-b51049d6d44d" />

> 로그 한 번만 나오는 것 확인!

<img width="525" height="52" alt="image" src="https://github.com/user-attachments/assets/29c4f862-e407-414f-9cad-6693235d8ec5" />

> 폴더도 하나만 생성되는 것 확인!
