### PR TITLE
[FIX][#30]: 슬랙 배지 경로 불러오기 오류 수정

### DIFF
--- a/python_engine/core/recovery/utils/ffmpeg_wrapper.py
+++ b/python_engine/core/recovery/utils/ffmpeg_wrapper.py
@@ -3,7 +3,7 @@ import os
 
 # FFmpeg 실행 파일 경로 
 FFMPEG_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '../../../bin/ffmpeg.exe')
+    os.path.join(os.path.dirname(__file__), '../../../../bin/ffmpeg.exe')
 )
 
 def convert_video(input_path, output_path, extra_args=None, use_gpu=True):

--- a/src/pages/Recovery.jsx
+++ b/src/pages/Recovery.jsx
@@ -648,14 +648,20 @@ useEffect(() => {
   }, []);
 
   // 22 슬랙 배지 처리 함수
- const handleSlackBadgeClick = (originVideo) => {
-   if (!originVideo) return;
-   const url = window.api?.toFileUrl
-     ? window.api.toFileUrl(originVideo)
-     : `file:///${originVideo.replace(/\\/g, "/")}`;
-   setSlackVideoSrc(url);
-   setShowSlackPopup(true);
- };
+  const fileByName = useMemo(() => {
+    const map = new Map();
+    (results || []).forEach(f => map.set(f.name, f));
+    return (name) => map.get(name);
+  }, [results]);
+
+  const handleSlackBadgeClick = (videoPath) => {
+    const url = window.api?.toFileUrl
+      ? window.api.toFileUrl(videoPath)
+      : `file:///${videoPath.replace(/\\/g, "/")}`;
+    setSlackVideoSrc(url);    
+    setShowSlackPopup(true);
+  };
+
 
   return (
     <div className={`recovery-page ${isDarkMode ? 'dark-mode' : ''}`}>
@@ -1053,10 +1059,10 @@ useEffect(() => {
                                         <Badge
                                           label="슬랙"
                                           style={{
-                                            cursor: file.slack_info ? "pointer" : "not-allowed",
-                                            opacity: file.slack_info ? 1 : 0.5,
+                                            cursor: file.slack_info?.video_path ? "pointer" : "not-allowed",
+                                            opacity: file.slack_info?.video_path ? 1 : 0.5,
                                           }}
-                                          onClick={() => file.origin_video && handleSlackBadgeClick(file.origin_video)}
+                                          onClick={() => file.slack_info?.video_path && handleSlackBadgeClick(file.slack_info.video_path)}
                                         />
                                     )}
                                   </div>


### PR DESCRIPTION
## 작업 내용 & 확인 요청
> 원래 슬랙 배지 누르면 뷰어 잘 뜨던게 갑자기 안 되길래 그 부분 수정했습니다! 
수정 사항 다음과 같습니다. 

슬랙 배지 누르면 경로 불러오는 부분이 뭘 해도 오류가 뜨길래 json을 열어보니까, 실제로 slack 폴더는 비어있는데 video_path에는 slack 경로가 들어간게 보였어요. 
<img width="803" height="412" alt="image" src="https://github.com/user-attachments/assets/f30ecb49-7265-4b9f-991f-a4cba0c706d9" />
<img width="828" height="238" alt="image" src="https://github.com/user-attachments/assets/43d4b2d0-acd9-4d36-aeb0-890c93dc5f8d" />

전에 json 구조 정리한 pr을 다 돌려봤는데, 안 쓴느 변수들 정리하거나 단위를 정리하고 video_path 부분은 건드시질 않은거 같아요. 찾아보니 그 부분을 고치신 않으신거같아요.(맞..나요..??)
그땐 저도 슬랙 배지를 신경 안 쓰고 있어서 발견하지 못했습니다. 혹시 백엔드 어떤 부분에서 처리를 바꾸신게 아닐지... 조심스레 여쭤봅니닷 😃😃

retato 시절에(?) video_path로 접근해서 잘 된거같은데 - 지금 slack 폴더가 비어서 가져오는게 오류난 거였더라고요.
일단 video_path 말고 origin_video 쓰니까 잘 돌아갑니다! 프론트 작업에서는 어차피 origin_video쓰면 되니까 video_path가 상관은 없지만 심사 시에 slack이 비어있으면 구현 쪽에서 감점이 될까봐 걱정이긴 합니닷..... 
혹시 제가 놓친 부분 있다면 말해주세요!