### PR TITLE
[FEAT][#41]: 단일 영상 파일(MP4, AVI, JDR) 파서 분리 및 지원

### DIFF
--- a/python_engine/core/analyzer/basic_info_parser.py
+++ b/python_engine/core/analyzer/basic_info_parser.py
@@ -24,7 +24,7 @@ def file_format(file_path):
     return 'Unknown'
 
 # 파일 생성/수정/접근 시간 정보 반환
-def file_creation_time(file_path):
+def file_timestamps(file_path):
     created = os.path.getctime(file_path)
     modified = os.path.getmtime(file_path)
     accessed = os.path.getatime(file_path)
@@ -108,18 +108,29 @@ def video_metadata(file_path):
 def get_basic_info(file_path):
     return {
         "format": file_format(file_path),
-        "timestamps": file_creation_time(file_path),
+        "timestamps": file_timestamps(file_path),
         "video_metadata": video_metadata(file_path)
     }
 
 # E01 메타데이터 기반 버전
 def get_basic_info_with_meta(file_path, meta):
+    # meta가 None이거나 속성이 없을 때 안전하게 처리
+    created = format_timestamp(getattr(meta, 'crtime', None)) if meta else None
+    modified = format_timestamp(getattr(meta, 'mtime', None)) if meta else None
+    accessed = format_timestamp(getattr(meta, 'atime', None)) if meta else None
+
+    # meta가 없으면 파일 시스템의 타임스탬프 사용
+    if not any([created, modified, accessed]):
+        timestamps = file_timestamps(file_path)
+    else:
+        timestamps = {
+            "created": created,
+            "modified": modified,
+            "accessed": accessed
+        }
+
     return {
         "format": file_format(file_path),
-        "timestamps": {
-            "created": format_timestamp(meta.crtime),
-            "modified": format_timestamp(meta.mtime),
-            "accessed": format_timestamp(meta.atime)
-        },
+        "timestamps": timestamps,
         "video_metadata": video_metadata(file_path)
     }

--- a/python_engine/core/image_loader/single_video_parser.py
+++ b/python_engine/core/image_loader/single_video_parser.py
@@ -1,0 +1,95 @@
+import os
+import json
+import tempfile
+import time
+from python_engine.core.recovery.mp4.extract_slack import recover_mp4_slack
+from python_engine.core.recovery.avi.extract_slack import recover_avi_slack
+from python_engine.core.analyzer.basic_info_parser import get_basic_info_with_meta
+from python_engine.core.analyzer.integrity import get_integrity_info
+from python_engine.core.analyzer.struc import get_structure_info
+from python_engine.core.recovery.utils.unit import bytes_to_unit
+
+VIDEO_EXTENSIONS = ('.mp4', '.avi', '.jdr')
+
+def build_analysis(origin_video_path, meta=None):
+    return {
+        'basic': get_basic_info_with_meta(origin_video_path, meta),
+        'integrity': get_integrity_info(origin_video_path),
+        'structure': get_structure_info(origin_video_path),
+    }
+
+def handle_single_video_file(filepath, output_dir):
+    ext = os.path.splitext(filepath)[1].lower()
+    name = os.path.basename(filepath)
+    with open(filepath, 'rb') as rf:
+        data = rf.read()
+
+    category = "single"
+    orig_dir = os.path.join(output_dir, category)
+    os.makedirs(orig_dir, exist_ok=True)
+    original_path = os.path.join(orig_dir, name)
+    with open(original_path, 'wb') as wf:
+        wf.write(data)
+
+    # 원본 파일의 타임스탬프를 meta로 전달
+    class Meta:
+        crtime = os.path.getctime(filepath)
+        mtime = os.path.getmtime(filepath)
+        atime = os.path.getatime(filepath)
+    meta = Meta()
+
+    if ext == '.mp4':
+        slack_dir = os.path.join(orig_dir, 'slack')
+        os.makedirs(slack_dir, exist_ok=True)
+        slack_info = recover_mp4_slack(
+            filepath=original_path,
+            output_h264_dir=slack_dir,
+            output_video_dir=slack_dir,
+            target_format="mp4",
+            use_gpu=False
+        )
+        origin_video_path = slack_info.get('source_path', original_path)
+        result = {
+            'name': name,
+            'path': filepath,
+            'size': bytes_to_unit(len(data)),
+            'origin_video': origin_video_path,
+            'slack_info': slack_info,
+            'analysis': build_analysis(origin_video_path, meta)
+        }
+    elif ext == '.avi':
+        avi_info = recover_avi_slack(
+            input_avi=original_path,
+            base_dir=orig_dir,
+            target_format="mp4",
+            use_gpu=False
+        )
+        origin_video_path = avi_info.get('source_path', avi_info.get('origin_path', original_path))
+        channels_only = {k: v for k, v in avi_info.items() if isinstance(v, dict)}
+        result = {
+            'name': name,
+            'path': filepath,
+            'size': bytes_to_unit(len(data)),
+            'origin_video': origin_video_path,
+            'channels': channels_only,
+            'analysis': build_analysis(origin_video_path, meta)
+        }
+    elif ext == '.jdr':
+        result = {
+            'name': name,
+            'path': filepath,
+            'size': bytes_to_unit(len(data)),
+            'origin_video': original_path,
+            'analysis': build_analysis(original_path, meta)
+        }
+    else:
+        return None
+
+    return result
+
+def extract_from_single_video(video_path):
+    temp_base = tempfile.gettempdir()
+    output_dir = tempfile.mkdtemp(prefix="Virex_", dir=temp_base)
+    result = handle_single_video_file(video_path, output_dir)
+    print(json.dumps({"tempDir": output_dir}), flush=True)
+    return [result] if result else [], output_dir, 1 if result else 0

--- a/python_engine/core/recovery/avi/extract_slack.py
+++ b/python_engine/core/recovery/avi/extract_slack.py
@@ -158,7 +158,7 @@ def extract_first_frame(video_path, out_jpeg, force_input_format):
     except Exception:
         return False
 
-def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
+def recover_avi_slack(input_avi, base_dir, target_format='mp4', use_gpu=False):
     os.makedirs(base_dir, exist_ok=True)
     with open(input_avi, "rb") as f:
         data = f.read()
@@ -225,7 +225,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
                             logger.warning(f"[{label}] 프레임 1장 케이스에서 이미지 추출 실패")
                     else:
                         slack_mp4 = os.path.join(ch_dir, f"{basename}_{label}_slack.{target_format}")
-                        convert_video(slack_h264, slack_mp4, extra_args=common_args)
+                        convert_video(slack_h264, slack_mp4, extra_args=common_args, use_gpu=use_gpu)
 
                         try:
                             os.remove(slack_h264)
@@ -286,7 +286,7 @@ def recover_avi_slack(input_avi, base_dir, target_format='mp4'):
 
             full_mp4 = os.path.join(ch_dir, f"{basename}_{label}.{target_format}")
             try:
-                convert_video(raw_fn, full_mp4, extra_args=common_args)
+                convert_video(raw_fn, full_mp4, extra_args=common_args, use_gpu=use_gpu)
             finally:
                 try:
                     os.remove(raw_fn)

--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -27,7 +27,7 @@ def _process_one_mp4(path: str, h264_root: str, out_root: str):
     out_dir  = os.path.join(out_root,  base)
     os.makedirs(h264_dir, exist_ok=True)
     os.makedirs(out_dir,  exist_ok=True)
-    return recover_mp4_slack(path, h264_dir, out_dir, target_format="mp4")
+    return recover_mp4_slack(path, h264_dir, out_dir, target_format="mp4", use_gpu=False)
 
 def _choose_workers(max_cap=4):
     cpu = os.cpu_count() or 4
@@ -182,7 +182,7 @@ def extract_first_frame(video_path, out_jpeg):
     except Exception:
         return False
     
-def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format="mp4"):
+def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format="mp4", use_gpu=False):
     os.makedirs(output_h264_dir, exist_ok=True)
     os.makedirs(output_video_dir, exist_ok=True)
 
@@ -229,7 +229,7 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
             return _fail_result()
 
         try:
-            convert_video(h264_path, mp4_path, extra_args=['-c:v', 'copy'])
+            convert_video(h264_path, mp4_path, extra_args=['-c:v', 'copy'], use_gpu=use_gpu, wait=True)
             logger.info(f"{filename} → mp4 변환 완료")
         except Exception as convert_err:
             logger.error(f"{filename} → mp4 변환 실패: {convert_err}")

--- a/python_engine/main.py
+++ b/python_engine/main.py
@@ -5,6 +5,7 @@ import shutil
 from typing import Optional, List, Iterable, Set
 from python_engine.core.image_loader.e01_parser import extract_videos_from_e01
 from python_engine.core.output.download_frame import download_frames
+from python_engine.core.image_loader.single_video_parser import extract_from_single_video
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -36,6 +37,7 @@ def main(e01_path: str,
     tmp_json_path: Optional[str] = None
     output_dir: Optional[str] = None
 
+    ext = os.path.splitext(e01_path)[1].lower()
     is_cached_analysis = (
         os.path.isdir(e01_path) and
         os.path.isfile(os.path.join(e01_path, "analysis.json"))
@@ -47,13 +49,20 @@ def main(e01_path: str,
         with open(os.path.join(output_dir, "analysis.json"), "r", encoding="utf-8") as rf:
             results = json.load(rf)
         total_files = len(results)
-    else:
-        results, output_dir, total_files = extract_videos_from_e01(e01_path)
-
+    elif ext in ('.mp4', '.avi', '.jdr'):
+        results, output_dir, total_files = extract_from_single_video(e01_path)
         if total_files == 0 or not results:
             print(json.dumps([]), flush=True)
             return
-
+        os.makedirs(output_dir, exist_ok=True)
+        tmp_json_path = os.path.join(output_dir, "analysis.json")
+        with open(tmp_json_path, "w", encoding="utf-8") as wf:
+            json.dump(results, wf, ensure_ascii=False, indent=2)
+    else:
+        results, output_dir, total_files = extract_videos_from_e01(e01_path)
+        if total_files == 0 or not results:
+            print(json.dumps([]), flush=True)
+            return
         os.makedirs(output_dir, exist_ok=True)
         tmp_json_path = os.path.join(output_dir, "analysis.json")
         with open(tmp_json_path, "w", encoding="utf-8") as wf:


### PR DESCRIPTION
## 작업 내용
> 기존에는 E01 이미지 파일만 복원 및 분석 대상으로 처리했으나, 이번 작업에서 **단일 영상 파일(MP4, AVI, JDR) 처리 기능을 새로 추가했습니다.** 이를 위해 단일 영상 파일 파서를 별도 파일로 분리하였고, 복원 및 분석 결과 구조를 기존 E01 파서와 동일하게 맞추었습니다.

### 작업 상세 내용
- [x] `image_loader` 폴더에 단일 영상 파일 파서(`single_video_parser.py`) 신규 생성
- [x] MP4, AVI, JDR 파일에 대한 복원 및 분석 로직 구현
- [x] `main.py`에서 확장자에 따라 적절한 파서 호출하도록 분기 처리
- [x] 기존 E01 파서와 결과 구조 통일

### 스크린샷
 
<img width="631" height="109" alt="image" src="https://github.com/user-attachments/assets/d433b69f-a6cc-4239-8509-d90a6169c5af" />

<img width="364" height="167" alt="image" src="https://github.com/user-attachments/assets/f10477f7-9479-4af5-8624-fc4cfd883a16" />

> MP4 단일 영상 파일 분석&복원 결과

<img width="1068" height="902" alt="image" src="https://github.com/user-attachments/assets/6ca1a32f-863e-4c67-b041-2489c0f3240e" />

> 구조 결과 통일

<img width="808" height="101" alt="image" src="https://github.com/user-attachments/assets/985a4349-4ea3-4e89-ac7c-924aa1a0bc77" />

<img width="790" height="116" alt="image" src="https://github.com/user-attachments/assets/7329f64b-0e8d-4ecf-8085-cd7d041541ab" />

> AVI 단일 영상 파일 분석&복원 결과

<img width="1128" height="906" alt="image" src="https://github.com/user-attachments/assets/578962d2-4ca7-407a-8ad2-f33a93576b49" />

> 구조 결과 통일

## 참고 사항
- 단일 영상 파일 처리 시 **GPU 인코딩 옵션은 사용하지 않도록 `use_gpu=False`로 명시**하였습니다.
- JDR 복원 로직은 아직 미구현 상태이므로 develop에 올라오는대로 추가 수정하겠습니다.
- 프론트엔드 파일 업로드 확장자 허용은 별도 이슈로 관리됩니다.
