### PR TITLE
[FEAT][#43]: 파일 업로드 확장자에 001/MP4/AVI/JDR 추가 허용

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('api', {
   selectFolder: () => ipcRenderer.invoke('dialog:openDirectory'),
   openDirectory: () => ipcRenderer.invoke('dialog:openDirectory'),
   openE01File: () => ipcRenderer.invoke('dialog:openE01File'),
+  openSupportedFile: () => ipcRenderer.invoke('dialog:openSupportedFile'),
   startRecovery: (e01Path) => ipcRenderer.invoke('start-recovery', e01Path),
   cancelRecovery: () => ipcRenderer.invoke('cancel-recovery'),
   onCancelled: (cb) => { const h = () => cb(); ipcRenderer.on('recovery-cancelled', h); return () => ipcRenderer.removeListener('recovery-cancelled', h); },

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -67,7 +67,7 @@ function ExplorerView({
   mountPath,
   currentPath,
   entries,
-  selectedE01,
+  selectedFile,
   onBack,
   onSelectDrive,
   onOpenDir,
@@ -83,7 +83,7 @@ function ExplorerView({
     navigate('/recovery', {
       state: {
         autoStart: true,
-        e01File: selectedE01
+        file: selectedFile
       }
     });
   };
@@ -132,16 +132,16 @@ function ExplorerView({
           </div>
 
           <div id="selected_file_info">
-            {selectedE01 && (
+            {selectedFile && (
               <div className="selected_box">
                 <h4 style={{ marginLeft: '10px' }}>선택된 파일</h4>
-                <p style={{ marginLeft: '10px' }}><strong>파일명:</strong> {selectedE01.name}</p>
-                <p style={{ marginLeft: '10px' }}><strong>크기:</strong> {bytesToGB(selectedE01.size)}</p>
-                <p style={{ marginLeft: '10px' }}><strong>경로:</strong> {selectedE01.path}</p>
+                <p style={{ marginLeft: '10px' }}><strong>파일명:</strong> {selectedFile.name}</p>
+                <p style={{ marginLeft: '10px' }}><strong>크기:</strong> {bytesToGB(selectedFile.size)}</p>
+                <p style={{ marginLeft: '10px' }}><strong>경로:</strong> {selectedFile.path}</p>
                 <Button
                   variant="dark"
                   onClick={handleStart}
-                  disabled={!selectedE01 || !selectedE01.path || !selectedE01.name}
+                  disabled={!selectedFile || !selectedFile.path || !selectedFile.name}
                 >
                   복원 시작
                 </Button>
@@ -174,7 +174,7 @@ const Home = ({ isDarkMode }) => {
   const [drives, setDrives] = useState([]);
   const [currentPath, setCurrentPath] = useState('');
   const [entries, setEntries] = useState([]);
-  const [selectedE01, setSelectedE01] = useState(null);
+  const [selectedFile, setSelectedFile] = useState(null);
   const [mountPath, setMountPath] = useState('');
 
   useEffect(() => {
@@ -193,14 +193,14 @@ const Home = ({ isDarkMode }) => {
 
   const loadFolder = useCallback(async (folderPath) => {
     setCurrentPath(folderPath);
-    setSelectedE01(null);
+    setSelectedFile(null);
     const raw = await window.api.readFolder(folderPath);
     raw.sort((a, b) => {
       if (a.isDirectory && !b.isDirectory) return -1;
       if (!a.isDirectory && b.isDirectory) return 1;
       return a.name.localeCompare(b.name);
     });
-    setEntries(raw.filter((e) => e.isDirectory || e.isE01));
+    setEntries(raw.filter((e) => e.isDirectory || e.isSupported));
   }, []);
 
   const handleDriveClick = (mount) => {
@@ -222,7 +222,7 @@ const Home = ({ isDarkMode }) => {
   };
 
   const handleOpenDir = (p) => loadFolder(p);
-  const handleSelectE01 = (entry) => setSelectedE01(entry);
+  const handleSelectFile = (entry) => setSelectedFile(entry);
 
   return (
     <div className={`main_content ${isDarkMode ? 'dark-mode' : ''}`}>
@@ -255,11 +255,11 @@ const Home = ({ isDarkMode }) => {
           mountPath={mountPath}
           currentPath={currentPath}
           entries={entries}
-          selectedE01={selectedE01}
+          selectedFile={selectedFile}
           onBack={handleBack}
           onSelectDrive={handleSelectDrive}
           onOpenDir={handleOpenDir}
-          onSelectE01={handleSelectE01}
+          onSelectFile={handleSelectFile}
           isDarkMode={isDarkMode}
         />
       )}


### PR DESCRIPTION
## 작업 내용
> Recovery 페이지에서 `.001`, `.mp4`, `.avi`, `.jdr` 파일 업로드 및 복원이 가능하도록 확장자 허용을 추가했습니다.

### 작업 상세 내용
- [x] Recovery 업로드 허용 확장자 확대: `.001`, `.mp4`, `.avi`, `.jdr` 추가
- [x] 파일 선택 다이얼로그에 `Supported` 필터 추가 및 Alert UI 정리
- [x] 업로드 가이드 문구 개선
- [x] Home 화면에서 단일 파일 입력 UX 확인 및 안내 문구 보강 

### 스크린샷
<img width="1561" height="913" alt="image" src="https://github.com/user-attachments/assets/85de3414-8969-4c52-902b-3403fcf695dc" />

> Home 화면 내에서 단일 파일 입력 받을 수 있습니다.

<img width="1559" height="907" alt="image" src="https://github.com/user-attachments/assets/8b2904a8-3de4-4be2-8201-f15983445393" />

> Recovery 화면 내 UI 개선

<img width="1155" height="641" alt="image" src="https://github.com/user-attachments/assets/ef197893-b3f8-49f7-8860-49d1b1a46d49" />

> 파일 선택 `Supported`로 선택되어 있는 경우

<img width="1129" height="631" alt="image" src="https://github.com/user-attachments/assets/4d3c3be3-d2dd-4823-8a8e-f47c16fc1493" />

> 파일 선택 `All Files`로 선택되어 있는 경우

<img width="1555" height="910" alt="image" src="https://github.com/user-attachments/assets/c0fec0fd-af78-406f-aec9-63dbaeb3b1ee" />

> 파일 형식 오류 팝업
> 해당 알림창이 공용 레이아웃 클래스를 사용하고 있지 않아 해당 부분 수정 했습니다.

<img width="1545" height="901" alt="image" src="https://github.com/user-attachments/assets/75db6652-cae4-4282-a29e-1eee46d69d27" />

> 단일 파일 선택한 경우

<img width="1554" height="906" alt="image" src="https://github.com/user-attachments/assets/9d5e44f5-2ac8-4900-9fcf-330ff44d8367" />
<img width="1264" height="755" alt="image" src="https://github.com/user-attachments/assets/85008b73-02cf-4961-9485-367fc9b3a395" />

> 복원 결과
 
## 리뷰 요구사항
- 단일 파일의 경우 프로그래스 바가 0%에서 멈춘 것처럼 보이는 문제가 있습니다. 
  이는 진행률 계산이 `processed / total (파일 단위)`되어 있어, 파일이 하나일 경우 내부 단계가 진행돼도 processed 값은 0으로 남아 있기 때문입니다.
   - AVI는 채널/슬랙 단계, MP4는 슬랙/분석 단계별로 나눠서 진행률을 갱신하는 방식을 적용하는 게 좋을지 의견 부탁드립니다.

## 참고사항
- 파일 형식 오류 Alert의 안내 문구와 버튼 UI를 개선했고, Alert가 뜰 때 업로드 버튼이 겹치지 않도록 조건부 렌더링을 적용했습니다.
