### PR TITLE
[FEAT][#45]: MP4 손상 복구 시 전체 파일 스캔 fallback 추가

### DIFF
--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -113,6 +113,13 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
         else origin_video_path
     )
 
+    try:
+        has_slack_output = bool(slack_info.get('video_path') or slack_info.get('image_path'))
+        if not has_slack_output and os.path.exists(slack_dir):
+            os.rmdir(slack_dir)
+    except Exception:
+        pass
+
     return {
         'name': name,
         'path': filepath,

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -69,11 +69,11 @@ def read_file_content(file_obj):
         offset += len(chunk)
     return buffer.getvalue()
 
-def build_analysis(origin_video_path, meta):
+def build_analysis(basic_target_path, origin_video_path, meta):
     return {
-        'basic': get_basic_info_with_meta(origin_video_path, meta),
+        'basic': get_basic_info_with_meta(basic_target_path, meta),
         'integrity': get_integrity_info(origin_video_path),
-        'structure': get_structure_info(origin_video_path),
+        'structure': get_structure_info(basic_target_path),
     }
 
 def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
@@ -109,7 +109,7 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
         'size': bytes_to_unit(len(data)),
         'origin_video': origin_video_path,
         'slack_info': slack_info,
-        'analysis': build_analysis(analysis_target, file_obj.info.meta)
+        'analysis': build_analysis(analysis_target, origin_video_path, file_obj.info.meta)
     }
 
 def handle_avi_file(name, filepath, data, file_obj, output_dir, category):

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -95,6 +95,13 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
     )
 
     origin_video_path = slack_info.get('source_path', original_path)
+    recovered_mp4 = slack_info.get('video_path')
+    
+    analysis_target = (
+        recovered_mp4
+        if (slack_info.get('recovered') and recovered_mp4 and os.path.exists(recovered_mp4))
+        else origin_video_path
+    )
 
     return {
         'name': name,
@@ -102,7 +109,7 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
         'size': bytes_to_unit(len(data)),
         'origin_video': origin_video_path,
         'slack_info': slack_info,
-        'analysis': build_analysis(origin_video_path, file_obj.info.meta)
+        'analysis': build_analysis(analysis_target, file_obj.info.meta)
     }
 
 def handle_avi_file(name, filepath, data, file_obj, output_dir, category):

--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -93,6 +93,16 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
         output_video_dir=slack_dir,
         target_format="mp4"
     )
+    if not slack_info:
+        slack_info = {
+            "recovered": False,
+            "video_path": None,
+            "image_path": None,
+            "is_image_fallback": False,
+            "slack_size": "0 B",
+            "slack_rate": 0.0,
+            "source_path": original_path
+        }
 
     origin_video_path = slack_info.get('source_path', original_path)
     recovered_mp4 = slack_info.get('video_path')

--- a/python_engine/core/image_loader/single_video_parser.py
+++ b/python_engine/core/image_loader/single_video_parser.py
@@ -49,13 +49,21 @@ def handle_single_video_file(filepath, output_dir):
             use_gpu=False
         )
         origin_video_path = slack_info.get('source_path', original_path)
+        recovered_mp4 = slack_info.get('video_path')
+
+        analysis_target = (
+            recovered_mp4
+            if (slack_info.get('recovered') and recovered_mp4 and os.path.exists(recovered_mp4))
+            else origin_video_path
+        )
+        
         result = {
             'name': name,
             'path': filepath,
             'size': bytes_to_unit(len(data)),
             'origin_video': origin_video_path,
             'slack_info': slack_info,
-            'analysis': build_analysis(origin_video_path, meta)
+            'analysis': build_analysis(analysis_target, meta)
         }
     elif ext == '.avi':
         avi_info = recover_avi_slack(

--- a/python_engine/core/image_loader/single_video_parser.py
+++ b/python_engine/core/image_loader/single_video_parser.py
@@ -11,11 +11,11 @@ from python_engine.core.recovery.utils.unit import bytes_to_unit
 
 VIDEO_EXTENSIONS = ('.mp4', '.avi', '.jdr')
 
-def build_analysis(origin_video_path, meta=None):
+def build_analysis(basic_target_path, origin_video_path, meta=None):
     return {
-        'basic': get_basic_info_with_meta(origin_video_path, meta),
+        'basic': get_basic_info_with_meta(basic_target_path, meta),
         'integrity': get_integrity_info(origin_video_path),
-        'structure': get_structure_info(origin_video_path),
+        'structure': get_structure_info(basic_target_path),
     }
 
 def handle_single_video_file(filepath, output_dir):
@@ -63,7 +63,7 @@ def handle_single_video_file(filepath, output_dir):
             'size': bytes_to_unit(len(data)),
             'origin_video': origin_video_path,
             'slack_info': slack_info,
-            'analysis': build_analysis(analysis_target, meta)
+            'analysis': build_analysis(analysis_target, origin_video_path, meta)
         }
     elif ext == '.avi':
         avi_info = recover_avi_slack(

--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -78,6 +78,28 @@ def extract_sps_pps(moov_data):
     except (IndexError, struct.error) as e:
         logger.error(f"SPS/PPS 추출 실패: {e}")
         return b''
+    
+def extract_sps_pps_anywhere(data):
+    pos = 0
+    while True:
+        avcc_pos = data.find(b'avcC', pos)
+        if avcc_pos == -1:
+            return b''
+        try:
+            avcc_start = avcc_pos + 4
+            sps_len = struct.unpack('>H', data[avcc_start + 6:avcc_start + 8])[0]
+            sps_start = avcc_start + 8
+            sps = data[sps_start:sps_start + sps_len]
+
+            pps_len_start = sps_start + sps_len + 1
+            pps_len = struct.unpack('>H', data[pps_len_start:pps_len_start + 2])[0]
+            pps_start = pps_len_start + 2
+            pps = data[pps_start:pps_start + pps_len]
+
+            return NAL_START_CODE + sps + NAL_START_CODE + pps
+        except (IndexError, struct.error):
+            pos = avcc_pos + 4
+            continue
 
 def extract_frames(slack, offset, sps_pps, output_path):
     matches = []
@@ -121,6 +143,46 @@ def extract_frames(slack, offset, sps_pps, output_path):
             except (struct.error, IndexError):
                 continue
 
+    return recovered, recovered_bytes
+
+def extract_frames_from_whole_file(data, sps_pps, output_path):
+    matches = []
+    has_i_frame = False
+
+    for m in IFRAME_PATTERN.finditer(data):
+        matches.append((m.start()))
+        has_i_frame = True
+    for m in PFRAME_PATTERN.finditer(data):
+        matches.append((m.start()))
+    
+    matches.sort()
+    if not has_i_frame or len(matches) < 3:
+        logger.info("유효한 프레임 없음")
+        return 0, 0
+
+    recovered = 0
+    recovered_bytes = 0
+    with open(output_path, 'wb') as f:
+        f.write(sps_pps)
+        recovered_bytes += len(sps_pps)
+
+        for start in matches:
+            try:
+                size = struct.unpack('>I', data[start:start + 4])[0]
+                if size > MAX_CHUNK_SIZE or size < MIN_FRAME_SIZE:
+                    continue
+
+                end = start + 4 + size
+                if end > len(data):
+                    continue
+
+                chunk = (NAL_START_CODE + data[start + 4:end])
+                f.write(chunk)
+                recovered += 1
+                recovered_bytes += len(chunk)
+            except (struct.error, IndexError):
+                continue
+    
     return recovered, recovered_bytes
 
 def get_video_frame_count(video_path):
@@ -182,14 +244,29 @@ def extract_first_frame(video_path, out_jpeg):
     except Exception:
         return False
     
+def _paths_for(filename, h264_dir, out_dir, suffix):
+    h264_path = os.path.join(h264_dir, f"{filename}_{suffix}.h264")
+    mp4_path  = os.path.join(out_dir,  f"{filename}_{suffix}.mp4")
+    jpeg_path = os.path.join(out_dir,  f"{filename}_{suffix}.jpeg")
+    return h264_path, mp4_path, jpeg_path
+
+def _fail_result():
+    return {
+        "recovered": False,
+        "slack_size": "0 B",
+        "video_path": None,
+        "image_path": None,
+        "is_image_fallback": False,
+        "slack_rate": 0.0,
+    }
+
 def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format="mp4", use_gpu=False):
     os.makedirs(output_h264_dir, exist_ok=True)
     os.makedirs(output_video_dir, exist_ok=True)
 
     filename = os.path.splitext(os.path.basename(filepath))[0]
-    h264_path = os.path.join(output_h264_dir, f"{filename}_slack.h264")
-    mp4_path  = os.path.join(output_video_dir, f"{filename}_slack.{target_format}")
-    jpeg_path = os.path.join(output_video_dir, f"{filename}_slack.jpeg")
+
+    h264_path, mp4_path, jpeg_path = _paths_for(filename, output_h264_dir, output_video_dir, "slack")
 
     try:
         with open(filepath, 'rb') as f:
@@ -198,35 +275,37 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
         slack, slack_offset, moov_data = get_slack_after_moov(data)
         
         if slack_offset is None:
-            logger.error(f"{filename} → moov 박스 없음 → 복원 불가")
-            if os.path.exists(h264_path):
-                try:
-                    os.remove(h264_path)
-                except Exception:
-                    pass
-            return _fail_result()
+            logger.warning(f"{filename} → moov/슬랙 탐지 실패 → 전체 스캔 fallback")
+            h264_path, mp4_path, jpeg_path = _paths_for(filename, output_h264_dir, output_video_dir, "damaged")
+            return _fallback_wholefile(
+                data=data, filename=filename,
+                h264_path=h264_path, mp4_path=mp4_path, jpeg_path=jpeg_path,
+                use_gpu=use_gpu
+            )
         
         sps_pps = extract_sps_pps(moov_data)
         if not sps_pps:
-            logger.info(f"{filename} → SPS/PPS 추출 실패")
-            if os.path.exists(h264_path):
-                try:
-                    os.remove(h264_path)
-                except Exception:
-                    pass
-            return _fail_result()
+            logger.info(f"{filename} → SPS/PPS 추출 실패 → 전체 스캔 fallback")
+            h264_path, mp4_path, jpeg_path = _paths_for(filename, output_h264_dir, output_video_dir, "damaged")
+            return _fallback_wholefile(
+                data=data, filename=filename,
+                h264_path=h264_path, mp4_path=mp4_path, jpeg_path=jpeg_path,
+                use_gpu=use_gpu
+            )
 
         frame_count, recovered_bytes = extract_frames(slack, slack_offset, sps_pps, h264_path)
         slack_rate = round((recovered_bytes / len(data) * 100), 2) if len(data) else 0.0
 
         if frame_count == 0:
-            if os.path.exists(h264_path):
-                try:
-                    os.remove(h264_path)
-                except Exception:
-                    pass
-            logger.info(f"{filename} → 유효한 프레임 없음")
-            return _fail_result()
+            logger.info(f"{filename} → 슬랙 내 유효 프레임 없음 → 전체 스캔 fallback")
+            try: os.remove(h264_path)
+            except: pass
+            h264_path, mp4_path, jpeg_path = _paths_for(filename, output_h264_dir, output_video_dir, "damaged")
+            return _fallback_wholefile(
+                data=data, filename=filename,
+                h264_path=h264_path, mp4_path=mp4_path, jpeg_path=jpeg_path,
+                use_gpu=use_gpu
+            )
 
         try:
             convert_video(h264_path, mp4_path, extra_args=['-c:v', 'copy'], use_gpu=use_gpu, wait=True)
@@ -242,7 +321,6 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
                 pass
         
         if os.path.exists(mp4_path):
-            fcount = get_video_frame_count(mp4_path)
             duration = get_video_duration_sec(mp4_path)
 
             # 1초 미만 영상이면 mp4 삭제, jpeg 생성
@@ -298,12 +376,78 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
                 pass
         return _fail_result()
     
-def _fail_result():
-    return {
-        "recovered": False,
-        "slack_size": "0 B",
-        "video_path": None,
-        "image_path": None,
-        "is_image_fallback": False,
-        "slack_rate": 0.0,
-    }
+def _fallback_wholefile(data, filename, h264_path, mp4_path, jpeg_path, use_gpu):
+    sps_pps_any = extract_sps_pps_anywhere(data)
+
+    frame_count, recovered_bytes = extract_frames_from_whole_file(
+        data=data,
+        sps_pps=sps_pps_any,
+        output_path=h264_path
+    )
+    slack_rate = round((recovered_bytes / len(data) * 100), 2) if len(data) else 0.0
+
+    if frame_count == 0:
+        if os.path.exists(h264_path):
+            try:
+                os.remove(h264_path)
+            except Exception:
+                pass
+        return _fail_result()
+    
+    try:
+        convert_video(h264_path, mp4_path, extra_args=['-c:v', 'copy'], use_gpu=use_gpu, wait=True)
+        logger.info(f"[fallback] {filename} → mp4 변환 완료")
+    except Exception as convert_err:
+        logger.error(f"[fallback] {filename} → mp4 변환 실패: {convert_err}")
+
+    if os.path.exists(h264_path):
+        try:
+            os.remove(h264_path)
+        except Exception:
+            pass
+
+    if os.path.exists(mp4_path):
+        duration = get_video_duration_sec(mp4_path)
+
+        # 1초 미만 영상이면 mp4 삭제, jpeg 생성
+        if duration is not None and duration < 1.0:
+            ok = extract_first_frame(mp4_path, jpeg_path)
+            try:
+                os.remove(mp4_path)
+            except Exception:
+                pass
+            if ok:
+                final_size = os.path.getsize(jpeg_path) if os.path.exists(jpeg_path) else recovered_bytes
+                return {
+                    "recovered": True,
+                    "slack_size": bytes_to_unit(int(final_size)),
+                    "video_path": None,
+                    "image_path": jpeg_path,
+                    "is_image_fallback": True,
+                    "slack_rate": slack_rate
+                }
+            else:
+                # jpeg 추출 실패 시 mp4 경로 반환
+                final_size = os.path.getsize(mp4_path)
+                return {
+                    "recovered": True,
+                    "slack_size": bytes_to_unit(int(final_size)),
+                    "video_path": mp4_path,
+                    "image_path": None,
+                    "is_image_fallback": False,
+                    "slack_rate": slack_rate
+                }
+        else:
+            # 1초 이상이면 mp4 경로 반환
+            final_size = os.path.getsize(mp4_path)
+            return {
+                "recovered": True,
+                "slack_size": bytes_to_unit(int(final_size)),
+                "video_path": mp4_path,
+                "image_path": None,
+                "is_image_fallback": False,
+                "slack_rate": slack_rate
+            }
+    
+    logger.info(f"[fallback] {filename} → mp4 생성 실패")
+    return _fail_result()


### PR DESCRIPTION
## 작업 내용
> MP4 원본에 moov/slack 영역이 없거나 손상된 경우,
> 파일 전체를 스캔하여 I/P 프레임을 추출한 뒤 h264 → mp4로 감싸는 fallback 로직을 추가했습니다.  
> 이때 결과물은 `_damaged` 접미사로 저장되도록 수정했습니다.

### 작업 상세 내용
- [x] recover_mp4_slack 내부에 전체 스캔 기반 fallback 연동
- [x] `_fallback_wholefile` 함수 추가
- [x] fallback 복구 결과는 `_damaged` 접미사로 저장

### 스크린샷
<img width="857" height="142" alt="image" src="https://github.com/user-attachments/assets/59ab7912-7829-47fa-9c97-67041fc5a364" />
<img width="333" height="195" alt="image" src="https://github.com/user-attachments/assets/fa300b96-6be2-4870-b003-ab8357b491ca" />
<img width="170" height="207" alt="image" src="https://github.com/user-attachments/assets/a4b0ef17-3d7f-4d6e-ade5-bb5123c70d96" />

> 결과 확인