### PR TITLE
[FIX][#48]: MP4 JSON 결과 버그 수정

### DIFF
--- a/python_engine/core/recovery/mp4/extract_slack.py
+++ b/python_engine/core/recovery/mp4/extract_slack.py
@@ -362,9 +362,20 @@ def recover_mp4_slack(filepath, output_h264_dir, output_video_dir, target_format
                         "slack_size": bytes_to_unit(int(final_size)),
                         "video_path": mp4_path,
                         "image_path": None,
-                        "is_image_fallback": False,
+                        "is_image_fallback": False, 
                         "slack_rate": slack_rate
                     }
+
+            final_size = os.path.getsize(mp4_path) if os.path.exists(mp4_path) else recovered_bytes
+            return {
+                "recovered": True,
+                "slack_size": bytes_to_unit(int(final_size)),
+                "video_path": mp4_path,
+                "image_path": None,
+                "is_image_fallback": False,
+                "slack_rate": slack_rate,
+            }
+        
         else:
             logger.error(f"{filename} → mp4 파일 미생성")
             return _fail_result()
@@ -440,6 +451,17 @@ def _fallback_wholefile(data, filename, h264_path, mp4_path, jpeg_path, use_gpu)
                     "is_image_fallback": False,
                     "slack_rate": slack_rate
                 }
+            
+        final_size = os.path.getsize(mp4_path) if os.path.exists(mp4_path) else recovered_bytes
+        return {
+            "recovered": True,
+            "slack_size": bytes_to_unit(int(final_size)),
+            "video_path": mp4_path,
+            "image_path": None,
+            "is_image_fallback": False,
+            "slack_rate": slack_rate,
+        }
     
-    logger.info(f"[fallback] {filename} → mp4 생성 실패")
-    return _fail_result()
+    else: 
+        logger.info(f"[fallback] {filename} → mp4 생성 실패")
+        return _fail_result()


### PR DESCRIPTION
## 작업 내용
> MP4 복원 후 analysis.json에 `video_path`, `slack_size`, `slack_rate` 등이 기록되지 않는 버그를 해결했습니다.

### 스크린샷
 <img width="1059" height="804" alt="image" src="https://github.com/user-attachments/assets/6ba42ccf-74c9-4e49-b04b-a9796809bfd4" />

> E01 복원 결과 (JSON)

<img width="1055" height="874" alt="image" src="https://github.com/user-attachments/assets/b7bde9cf-44ee-433d-807b-d38c91730551" />

> 손상된 MP4 단일 영상 복원 결과 (JSON)

## 사과의 말
제가 분명 오류를 다 고쳤다고 생각하고 이전 브랜치 머지했는데요,,,,,!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
이상하게 오류가 또 있더라구요??!?!?!?!?!!?!??
MP4는 진짜 진짜 JSON 결과까지 돌아가는 거 확인했습니다.
만약, AVI도 오류가 난다면 손상된 영상 처리할 때 해결하겠습니다😫😫😫😫😫😫
