### PR TITLE
[FEAT][#52]: AVI 손상 복구 시 fallback 로직 추가

### DIFF
--- a/python_engine/core/image_loader/e01_parser.py
+++ b/python_engine/core/image_loader/e01_parser.py
@@ -92,7 +92,8 @@ def handle_mp4_file(name, filepath, data, file_obj, output_dir, category):
         filepath=original_path,
         output_h264_dir=slack_dir,
         output_video_dir=slack_dir,
-        target_format="mp4"
+        target_format="mp4",
+        use_gpu=True
     )
     if not slack_info:
         slack_info = {
@@ -142,7 +143,8 @@ def handle_avi_file(name, filepath, data, file_obj, output_dir, category):
     avi_info = recover_avi_slack(
         input_avi=original_path,
         base_dir=orig_dir,
-        target_format="mp4"
+        target_format="mp4",
+        use_gpu=True
     )
     if avi_info is None:
         return None
@@ -150,7 +152,7 @@ def handle_avi_file(name, filepath, data, file_obj, output_dir, category):
     origin_video_path = avi_info.get('source_path', avi_info.get('origin_path', original_path))
     channels_only = {k: v for k, v in avi_info.items() if isinstance(v, dict)}
     
-    return {
+    result = {
         'name': name,
         'path': filepath,
         'size': bytes_to_unit(len(data)),
@@ -158,6 +160,11 @@ def handle_avi_file(name, filepath, data, file_obj, output_dir, category):
         'channels': channels_only,
         'analysis': build_analysis(origin_video_path, origin_video_path, file_obj.info.meta)
     }
+    
+    if 'video_metadata' in channels_only and 'analysis' in result and 'basic' in result['analysis']:
+        result['analysis']['basic']['video_metadata'] = channels_only['video_metadata']
+        del channels_only['video_metadata']
+    return result
 
 def handle_jdr_file(name, filepath, data, file_obj, output_dir, category):
     video_stem = os.path.splitext(name)[0]

--- a/python_engine/core/image_loader/single_video_parser.py
+++ b/python_engine/core/image_loader/single_video_parser.py
@@ -87,6 +87,9 @@ def handle_single_video_file(filepath, output_dir):
             'channels': channels_only,
             'analysis': build_analysis(origin_video_path, origin_video_path, meta)
         }
+        if 'video_metadata' in channels_only and 'analysis' in result and 'basic' in result['analysis']:
+            result['analysis']['basic']['video_metadata'] = channels_only['video_metadata']
+            del channels_only['video_metadata']
     elif ext == '.jdr':
         # JDR 파일은 extract_jdr을 사용하여 복원
         jdr_info = recover_jdr(

--- a/python_engine/core/recovery/utils/ffmpeg_wrapper.py
+++ b/python_engine/core/recovery/utils/ffmpeg_wrapper.py
@@ -5,7 +5,8 @@ from python_engine.core.analyzer.basic_info_parser import video_metadata
 # FFmpeg 실행 파일 경로 
 FFMPEG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../bin/ffmpeg.exe'))
 
-def convert_video(input_path, output_path, fps=None, extra_args=None, use_gpu=True, wait=True):
+
+def convert_video(input_path, output_path, extra_args=None, use_gpu=True, wait=True, fps=None):
     cmd = [FFMPEG_PATH, '-hide_banner', '-loglevel', 'info']
 
     try:
@@ -31,15 +32,27 @@ def convert_video(input_path, output_path, fps=None, extra_args=None, use_gpu=Tr
 
     # fps가 있으면 -r 옵션에 적용
     if wrapping_mode:
-        if fps:
-            cmd += ['-r', str(fps)]
+        if use_gpu:
+            if fps:
+                cmd += ['-r', str(fps)]
+            else:
+                cmd += ['-r', '30']
+            # GPU 인코더 적용
+            if vcodec == 'libx265':
+                gpu_codec = 'hevc_nvenc'
+            else:
+                gpu_codec = 'h264_nvenc'
+            cmd += [
+                '-hwaccel', 'cuda',
+                '-i', input_path,
+                '-c:v', gpu_codec, '-preset', 'p3', '-cq', '23',
+                '-movflags', '+faststart'
+            ]
         else:
-            cmd += ['-r', '30']
-        
-        # want_copy가 True이면 copy 옵션 사용, 아니면 인코딩
-        if want_copy:
-            cmd += ['-i', input_path, '-c:v', 'copy', '-movflags', '+faststart']
-        else:
+            if fps:
+                cmd += ['-r', str(fps)]
+            else:
+                cmd += ['-r', '30']
             cmd += ['-i', input_path, '-c:v', vcodec, '-preset', 'medium', '-crf', '23', '-movflags', '+faststart']
         cmd += [output_path]
     else:
@@ -51,6 +64,7 @@ def convert_video(input_path, output_path, fps=None, extra_args=None, use_gpu=Tr
                 gpu_codec = 'hevc_nvenc'
             else:
                 gpu_codec = 'h264_nvenc'
+            print(f"[INFO] ffmpeg | GPU codec: {gpu_codec}")
             cmd += [
                 '-hwaccel', 'cuda',
                 '-i', input_path,
@@ -67,13 +81,32 @@ def convert_video(input_path, output_path, fps=None, extra_args=None, use_gpu=Tr
                 '-c:a', 'aac', '-b:a', '192k',
                 '-movflags', '+faststart'
             ]
-        
         if extra_args:
             cmd += list(extra_args)
         cmd += [output_path]
 
     if wait:
-        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print(f"[INFO] ffmpeg | GPU={use_gpu} | wrapping_mode={wrapping_mode}")
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            print(f"[ERROR] ffmpeg 변환 실패!\n[stderr]\n{e.stderr.decode(errors='ignore')}")
+            # GPU 인코딩 실패 시 CPU 인코딩 fallback
+            if use_gpu:
+                print("[WARN] GPU 인코딩 실패, CPU(libx264)로 재시도합니다.")
+                cpu_cmd = [FFMPEG_PATH, '-hide_banner', '-loglevel', 'info']
+                if fps:
+                    cpu_cmd += ['-r', str(fps)]
+                else:
+                    cpu_cmd += ['-r', '30']
+                cpu_cmd += ['-i', input_path, '-c:v', 'libx264', '-preset', 'medium', '-crf', '23', '-movflags', '+faststart', output_path]
+                try:
+                    subprocess.run(cpu_cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+                except subprocess.CalledProcessError as e2:
+                    print(f"[ERROR] CPU 인코딩도 실패!\n[stderr]\n{e2.stderr.decode(errors='ignore')}")
+                    raise
+            else:
+                raise
         return None
     else:
         p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
## 작업 내용
> AVI 손상 시 복원 로직 추가했습니다 :)
> GPU도 함께 해결했습니다!

### 스크린샷
<img width="1209" height="495" alt="image" src="https://github.com/user-attachments/assets/b0add9e6-d319-4c7d-8749-af161086b72d" />
<img width="436" height="131" alt="image" src="https://github.com/user-attachments/assets/abf9f710-d33a-40fe-9237-abb85226b472" />

> 헤더 손상

<img width="1308" height="587" alt="image" src="https://github.com/user-attachments/assets/8d722ad8-0b71-469a-b73e-4fb4705075c5" />
<img width="656" height="392" alt="image" src="https://github.com/user-attachments/assets/af719b2d-ebc1-4609-a5b5-986afab3fcd5" />

> 푸터 손상

## 리뷰 요구사항
- 비디오가 손상된 경우에는 메타데이터도 못가져와서 복원된 영상의 메타데이터로 덮어씌우도록 처리를 했는데 괜찮나요..? 
<img width="394" height="221" alt="image" src="https://github.com/user-attachments/assets/805af80e-5cab-4560-9031-3258875554ad" />

- 그래서 지금 오디오의 메타데이터는 적히지 않음...ㅎㅎ (오디오는 slack으로 처리돼서 복원 되긴 합니다!)
- 아 근데 진짜 고민인게 그러면 영상도 슬랙 처리되야지 이게 매칭이돼서 오디오랑 merge가 되나...

