### PR TITLE
[FEAT][#62]: 손상된 AVI 복원 결과 UI 개선 (손상 뱃지/복원 비율 표시)

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -1,18 +1,25 @@
 import React from 'react';
 
-const Badge = ({ label, onClick, variant = "blue" }) => {
+const Badge = ({ label, onClick, variant = "blue", size = "default" }) => {
+  // size에 따라 height/lineHeight 변경
+  const isBig = size === 'big';
   const baseStyle = {
-    width: '64px',
-    minHeight: '20px',
+    width: '70px',
+    minWidth: '64px',
+    height: isBig ? '45px' : '28px',
+    minHeight: isBig ? '45px' : '20px',
+    lineHeight: isBig ? '45px' : '20px',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     fontSize: '0.75rem',
     fontWeight: 600,
-    padding: '4px 8px',
+    padding: isBig ? '8px 16px' : '4px 8px',
     borderRadius: '6px',
     border: 'none',
+    boxSizing: 'border-box',
     cursor: onClick ? 'pointer' : 'default',
+    transition: 'height 0.2s, line-height 0.2s, font-size 0.2s',
   };
 
   const colorStyles = {
@@ -23,10 +30,12 @@ const Badge = ({ label, onClick, variant = "blue" }) => {
 
   const style = { ...baseStyle, ...(colorStyles[variant] || colorStyles.blue) };
 
-  if (onClick) {
-    return <button style={style} onClick={onClick}>{label}</button>;
-  }
-  return <div style={style}>{label}</div>;
+  // 항상 button으로 렌더링
+  return (
+    <button style={style} onClick={onClick} type="button" tabIndex={0} disabled={!onClick}>
+      {label}
+    </button>
+  );
 };
 
 export default Badge;

--- a/src/pages/Recovery.jsx
+++ b/src/pages/Recovery.jsx
@@ -1933,6 +1933,7 @@ const handleDownloadConfirm = async () => {
                     key="audio"
                     label={<div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}><span>Audio</span></div>}
                     onClick={() => handleAudioPlay('slack', selectedSlackFile)}
+                    size="big"
                     style={{
                       cursor: 'pointer',
                       opacity: currentAudio?.file?.name === selectedSlackFile?.name ? 1 : 0.6,

--- a/src/pages/Recovery.jsx
+++ b/src/pages/Recovery.jsx
@@ -1669,9 +1669,6 @@ const handleDownloadConfirm = async () => {
                                             {isAVI && file?.analysis?.integrity?.damaged && Object.values(file.channels || {}).some(ch => ch?.full_video_path) && (
                                               <Badge label="복원 완료" variant="yellow" />
                                             )}
-                                            {isMP4 && file?.slack_info?.recovered && (
-                                              <Badge label="복원 완료" variant="yellow" />
-                                            )}
                                             {hasSlackBadge && !file?.analysis?.integrity?.damaged && (
                                               <Badge
                                                 label="슬랙"
@@ -1691,6 +1688,9 @@ const handleDownloadConfirm = async () => {
                                                 }}
                                                 variant="blue"
                                               />
+                                            )}
+                                            {isMP4 && file?.analysis?.integrity?.damaged && file?.slack_info?.recovered && (
+                                              <Badge label="복원 완료" variant="yellow" />
                                             )}
                                           </>
                                         )}

--- a/src/styles/Recovery.css
+++ b/src/styles/Recovery.css
@@ -672,7 +672,7 @@ input[type="checkbox"] {
   box-sizing: border-box;
   position: relative;
   height: 100%;
-  border-radius: 6px;
+  border-radius: 12px;
 }
 
 .data-bar-wrapper.is-single .data-bar-text {


### PR DESCRIPTION
## 작업 내용
> 손상된 AVI 파일 복원 결과를 사용자에게 명확히 보여주기 위해 UI를 개선하였습니다.

### 스크린샷
**1. 손상된 영상이 복원된 경우**
<img width="1014" height="601" alt="image" src="https://github.com/user-attachments/assets/ec26192c-ff2d-4230-971b-d875236360a0" />

> 슬랙 비율이 아닌 복원 비율
> 손상 및 복원 완료 뱃지

<img width="1024" height="614" alt="image" src="https://github.com/user-attachments/assets/2fed8e0f-349b-452f-8059-f145015a09f9" />
<img width="958" height="202" alt="image" src="https://github.com/user-attachments/assets/3e043830-11af-421e-bc3f-b38b386ef686" />
<img width="928" height="229" alt="image" src="https://github.com/user-attachments/assets/130e16d0-6ff5-407b-b2e6-83a7776ff789" />

> 분석 정보

**2. 손상된 영상이 복원도 되고 슬랙 영상도 나온 경우**
<img width="1010" height="612" alt="image" src="https://github.com/user-attachments/assets/d417891c-9c52-4be6-a82c-234fd021590c" />

> 해당 경우 용량, 복원 비율, 슬랙 비율 모두 나옵니다
> 뱃지 너무 많지 않나요??????????????????? 근데 쩔수..

<img width="1194" height="702" alt="image" src="https://github.com/user-attachments/assets/9d9413af-6235-4b36-9830-9b74d89f1d5f" />

> 슬랙 팝업

<img width="1011" height="609" alt="image" src="https://github.com/user-attachments/assets/83f05e3e-8e43-442b-97f9-9e2b2d5b3b4e" />
<img width="1009" height="604" alt="image" src="https://github.com/user-attachments/assets/8f545544-2778-478a-91b0-606c269979fb" />
<img width="1013" height="617" alt="image" src="https://github.com/user-attachments/assets/7b542b0a-8bd5-4c63-bebb-8607e4ab7ea1" />
<img width="1011" height="569" alt="image" src="https://github.com/user-attachments/assets/4cb967b2-1ff1-4cb6-a8fd-5916bb05a07d" />

> 분석 정보
> 복원과 슬랙이 모두 된 경우 슬랙 정보 탭이 `복원/슬랙 정보` 탭으로 변경됩니다.
> 마찬가지로 복원/슬랙 정보 탭에는 복원된 영상 관련 정보와 슬랙 영상 관련 정보가 모두 나타납니다.