### PR TITLE
[FEAT][#82]: 복원 진행 상태 알림 기능 추가

### DIFF
--- a/main.js
+++ b/main.js
@@ -565,14 +565,15 @@ ipcMain.handle('start-recovery', async (event, e01FilePath) => {
           lower.includes('critical')  ||
           lower.includes('fatal');
 
-        if (isSystemError) {
-          new Notification({
-            title: '복원 실패',
-            body: msg.slice(0, 100),
-            icon: iconPath
-          }).show();
-          errorNotified = true;
-        }
+          if (isSystemError) {
+            const notif = new Notification({
+              title: '복원 실패',
+              body: msg.slice(0, 100)
+            });
+            notif.appUserModelId = 'com.virex.app';
+            notif.show();
+            errorNotified = true;
+          }
       }
     });
 
@@ -617,13 +618,16 @@ ipcMain.handle('start-recovery', async (event, e01FilePath) => {
 
       try { win?.webContents.send('recovery-done');
 
-        if (notificationsEnabled) {
-          new Notification({
-            title: '복원 완료',
-            body: '복원이 완료되었습니다.',
-            icon: iconPath
-          }).show();
-        }
+          if (notificationsEnabled) {
+            try {
+              new Notification({
+                title: '복원 완료',
+                body: '복원이 완료되었습니다.'
+              }).show();
+            } catch (err) {
+              console.error('[알림 생성 에러]', err);
+            }
+          }
       } catch {}
       return code === 0 ? resolve() : reject(new Error(`exit ${code}`));
     });

--- a/preload.js
+++ b/preload.js
@@ -10,13 +10,13 @@ contextBridge.exposeInMainWorld('api', {
   openSupportedFile: () => ipcRenderer.invoke('dialog:openSupportedFile'),
   startRecovery: (e01Path) => ipcRenderer.invoke('start-recovery', e01Path),
 
-
   cancelRecovery: () => ipcRenderer.invoke('cancel-recovery'),
   clearCache: () => ipcRenderer.invoke('clear-cache'),
+
+  setNotifications: (enabled) => ipcRenderer.invoke('set-notifications', enabled),
   
   readCarvedIndex: (dir) => ipcRenderer.invoke('readCarvedIndex', dir),
   listCarvedDir: (baseDir) => ipcRenderer.invoke('listCarvedDir', baseDir),
-
 
   onDiskFull: (cb) => {
     const channel = 'recovery-disk-full';

--- a/src/pages/Recovery.jsx
+++ b/src/pages/Recovery.jsx
@@ -1200,7 +1200,7 @@ const handleDownloadConfirm = async () => {
                 onChange={handleFileChange}
                 hidden
               />
-              {!showAlert && (
+              {!showAlert && !showDiskFullAlert && (
                 <Button variant="gray">
                   ⭱ <span>업로드</span>
                 </Button>
@@ -2041,15 +2041,17 @@ const handleDownloadConfirm = async () => {
             </>
           }
         >
-          <Button
-            variant="dark"
-            onClick={() => {
-              setShowDiskFullAlert(false);      
-              diskFullHandledRef.current = false; 
-            }}
-          >
-            확인
-          </Button>
+          <div className="alert-buttons">
+            <Button
+              variant="dark"
+              onClick={() => {
+                setShowDiskFullAlert(false);      
+                diskFullHandledRef.current = false; 
+              }}
+            >
+              확인
+            </Button>
+          </div>
         </Alert>
       )}
 

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -20,6 +20,12 @@ const Settings = ({ isDarkMode, setIsDarkMode }) => {
     setTimeout(() => setShowCacheMessage(false), 4000);
   };
 
+  const handleNotificationToggle = () => {
+    const newValue = !notificationsOn;
+    setNotificationsOn(newValue);
+    window.api?.setNotifications(newValue);
+  };
+
   return (
     <div className={`settings_page ${isDarkMode ? 'dark-mode' : ''}`}>
       <h1 className="settings_title">Setting</h1>
@@ -70,7 +76,7 @@ const Settings = ({ isDarkMode, setIsDarkMode }) => {
             <input
               type="checkbox"
               checked={notificationsOn}
-              onChange={() => setNotificationsOn(!notificationsOn)}
+              onChange={handleNotificationToggle}
             />
             <span className="slider"></span>
           </label>


### PR DESCRIPTION
## 작업 내용
- Electron Notification API 연동
  - 복원 완료 시 알림 표시
  - 시스템적 오류(디스크 용량 부족 등)로 복원 실패 시 알림 표시 (세션당 1회)
  - fallback/파일 단위 실패는 알림 제외
  - 복원 완료/실패 알림에 Virex 아이콘 적용
- preload.js에 `setNotifications` 브리지 추가
  - Settings.jsx에서 알림 on/off 토글을 main 프로세스로 전달 가능
- Settings.jsx 수정
  - 알림 토글 UI → `window.api.setNotifications()`와 연동
  - 사용자 설정에 따라 알림 on/off 제어 가능

### 스크린샷

<img width="494" height="243" alt="image" src="https://github.com/user-attachments/assets/69f576e3-d8c0-4ba6-ab12-1ec2911eba5a" />
