### PR TITLE
[FIX][#85]: Information 페이지 내 Github 주소 제거

### DIFF
--- a/src/pages/Information.jsx
+++ b/src/pages/Information.jsx
@@ -35,13 +35,9 @@ const Information = ({ isDarkMode }) => {
               <th>개발자</th>
               <td>김세연, 마유진, 최리안</td>
             </tr>
-            <tr className="stack-divider">
+            <tr>
               <th>문의</th>
               <td>justvx2025@gmail.com</td>
-            </tr>
-            <tr>
-              <th>GitHub</th>
-              <td><a href="https://github.com/Team-JUST/Virex" target="_blank" rel="noreferrer" className={isDarkMode ? 'dark-mode' : ''}>https://github.com/Team-JUST/Virex</a></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## 작업 내용
> Information 페이지 내의 Github 주소 제거 했습니다.

### 스크린샷
<img width="1554" height="902" alt="image" src="https://github.com/user-attachments/assets/813698a5-ef88-4acc-b67f-d659e402548b" />